### PR TITLE
Fixed orderd list textPosition

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1760,7 +1760,7 @@ function matchHeader( lineToMatch ){
  * @returns {IRElement} | null if the expression doesn't match
  */
 function matchList( lineToMatch ){
-	const list = lineToMatch.match( /^(?:[\s])*(?:[*\-+] |(?<orderedNumber>[0-9]+)[.)] )+(?<listText>.*)$/i )
+  const list = lineToMatch.match( /^(?<witespace>\s*)(?:[*\-+] |(?<orderedNumber>[0-9]+)[.)] )+(?<listText>.*)$/i )
 	if( list
 		&& list.groups
 		&& list.groups.listText ){
@@ -1775,7 +1775,7 @@ function matchList( lineToMatch ){
 										: "bulletList",
 			typeParam:		list.groups.orderedNumber,
 			textToEmphasis: textIsCodeBlock ? '': list.groups.listText,
-			textPosition: 	lineToMatch.indexOf( list.groups.listText ) - 2,
+			textPosition: 	list.groups.witespace.length,
 			nodeAttached: 	textIsCodeBlock
 		}
 	}

--- a/source/markdownParsing.js
+++ b/source/markdownParsing.js
@@ -92,7 +92,7 @@ function matchHeader( lineToMatch ){
  * @returns {IRElement} | null if the expression doesn't match
  */
 function matchList( lineToMatch ){
-	const list = lineToMatch.match( /^(?:[\s])*(?:[*\-+] |(?<orderedNumber>[0-9]+)[.)] )+(?<listText>.*)$/i )
+  const list = lineToMatch.match( /^(?<witespace>\s*)(?:[*\-+] |(?<orderedNumber>[0-9]+)[.)] )+(?<listText>.*)$/i )
 	if( list
 		&& list.groups
 		&& list.groups.listText ){
@@ -107,7 +107,7 @@ function matchList( lineToMatch ){
 										: "bulletList",
 			typeParam:		list.groups.orderedNumber,
 			textToEmphasis: textIsCodeBlock ? '': list.groups.listText,
-			textPosition: 	lineToMatch.indexOf( list.groups.listText ) - 2,
+			textPosition: 	list.groups.witespace.length,
 			nodeAttached: 	textIsCodeBlock
 		}
 	}


### PR DESCRIPTION
The original regex doesn't work for orderd list like `19. blah`. The
number occupies 4 spaces, if we go `100. ` then it's five. It seems we
can capture the begining whitespaces directly instead